### PR TITLE
this.error -> node.error

### DIFF
--- a/pushover.js
+++ b/pushover.js
@@ -118,7 +118,7 @@ module.exports = function (RED) {
                         node.error('Error parsing json: ' + error.message);
                     }
                 }).on('error', function (err) {
-                    this.error('Pushover error: ' + err);
+                    node.error('Pushover error: ' + err);
                 });
             }
 
@@ -192,7 +192,7 @@ module.exports = function (RED) {
                         node.error('Error parsing json: ' + error.message);
                     }
                 }).on('error', function (err) {
-                    this.error('Pushover error: ' + err);
+                    node.error('Pushover error: ' + err);
                 });
             }
 


### PR DESCRIPTION
Fix for non-existent this.error function. When pushover.net was offline this morning, this bug caused my whole node-red to crash. The change redirects to node.error and resolved the issue.